### PR TITLE
Allow Tally embeds in site CSP

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta name="author" content="Strength Over Struggle Team" />
 
     <!-- Security Headers -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://code.tidio.co https://datafa.st; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://code.tidio.co; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://lovable.dev https://code.tidio.co; connect-src 'self' https://js.stripe.com https://checkout.stripe.com https://api.stripe.com https://code.tidio.co wss://code.tidio.co https://datafa.st; frame-src https://js.stripe.com https://checkout.stripe.com https://code.tidio.co; object-src 'none'; base-uri 'self'; form-action 'self' https://checkout.stripe.com;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://code.tidio.co https://datafa.st https://tally.so; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://code.tidio.co; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://lovable.dev https://code.tidio.co; connect-src 'self' https://js.stripe.com https://checkout.stripe.com https://api.stripe.com https://code.tidio.co wss://code.tidio.co https://datafa.st https://tally.so; frame-src https://js.stripe.com https://checkout.stripe.com https://code.tidio.co https://tally.so; object-src 'none'; base-uri 'self'; form-action 'self' https://checkout.stripe.com;">
     <meta http-equiv="X-Frame-Options" content="SAMEORIGIN">
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">


### PR DESCRIPTION
## Summary
- permit loading Tally scripts and frames by adding https://tally.so to the CSP meta tag
- extend connect-src to cover Tally requests so the embedded form can communicate reliably

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e15cc61008832989a82da7af309e5c