### PR TITLE
Refine contact modal responsiveness and theming

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -54,11 +54,12 @@ export const Header = ({
             >
               Shop
             </Link>
-            <TallyModal 
+            <TallyModal
               formId="n9bWWE"
               buttonText="Contact"
               buttonVariant="secondary"
-              className="text-secondary-foreground hover:text-primary transition-opacity hover:opacity-90 !bg-transparent !border-0 !p-0"
+              className="text-secondary-foreground hover:text-primary transition-opacity hover:opacity-90"
+              unstyled
             />
             <ThemeToggle />
             {showDonateButton && (
@@ -99,14 +100,18 @@ export const Header = ({
               >
                 Shop
               </Link>
-              <div onClick={() => setIsMenuOpen(false)}>
-                <TallyModal 
-                  formId="n9bWWE"
-                  buttonText="Contact"
-                  buttonVariant="secondary"
-                  className="text-left text-secondary-foreground hover:text-primary transition-opacity hover:opacity-90 !bg-transparent !border-0 !p-0 w-full"
-                />
-              </div>
+              <TallyModal
+                formId="n9bWWE"
+                buttonText="Contact"
+                buttonVariant="secondary"
+                className="text-left text-secondary-foreground hover:text-primary transition-opacity hover:opacity-90 w-full"
+                unstyled
+                onOpenChange={(open) => {
+                  if (!open) {
+                    setIsMenuOpen(false);
+                  }
+                }}
+              />
               <div className="flex items-center justify-between">
                 <span className="text-secondary-foreground">Theme</span>
                 <ThemeToggle />

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
   return (

--- a/src/hooks/useModalState.ts
+++ b/src/hooks/useModalState.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 interface UseModalStateReturn<T> {
   selectedItem: T | null;
@@ -14,8 +14,13 @@ interface UseModalStateReturn<T> {
 export function useModalState<T>(): UseModalStateReturn<T> {
   const [selectedItem, setSelectedItem] = useState<T | null>(null);
   const [isOpen, setIsOpen] = useState(false);
+  const cleanupTimeoutRef = useRef<number | null>(null);
 
   const openModal = (item: T) => {
+    if (cleanupTimeoutRef.current) {
+      window.clearTimeout(cleanupTimeoutRef.current);
+      cleanupTimeoutRef.current = null;
+    }
     setSelectedItem(item);
     setIsOpen(true);
   };
@@ -23,8 +28,19 @@ export function useModalState<T>(): UseModalStateReturn<T> {
   const closeModal = () => {
     setIsOpen(false);
     // Delay clearing the item to allow exit animation
-    setTimeout(() => setSelectedItem(null), 300);
+    cleanupTimeoutRef.current = window.setTimeout(() => {
+      setSelectedItem(null);
+      cleanupTimeoutRef.current = null;
+    }, 300);
   };
+
+  useEffect(() => {
+    return () => {
+      if (cleanupTimeoutRef.current) {
+        window.clearTimeout(cleanupTimeoutRef.current);
+      }
+    };
+  }, []);
 
   return {
     selectedItem,

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
   darkMode: ["class"],
@@ -140,5 +141,5 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- rebuild the custom `TallyModal` around the shared modal component so the contact dialog mirrors founder/story layouts, gains responsive height, and keeps the mobile embed visible
- switch the trigger to a theme-aware button/anchor hybrid with focus styling so the navigation "Contact" label respects light/dark modes like other links
- load the Tally form via iframe with a loading state and retain the shared `onOpenChange` hook integration so mobile navigation only closes after the dialog does

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68e18d2faf4c8329b43cec271a0a5918