### PR TITLE
Refactor Supabase client configuration

### DIFF
--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -6,15 +6,17 @@ import type { Database } from './types';
 const supabaseUrl = ENV.supabase.url;
 const supabaseKey = ENV.supabase.publishableKey;
 
+const missingEnvVars: string[] = [];
 if (!supabaseUrl) {
-  throw new Error(
-    'Missing Supabase configuration: VITE_SUPABASE_URL is not defined.'
-  );
+  missingEnvVars.push('VITE_SUPABASE_URL');
+}
+if (!supabaseKey) {
+  missingEnvVars.push('VITE_SUPABASE_PUBLISHABLE_KEY');
 }
 
-if (!supabaseKey) {
+if (missingEnvVars.length > 0) {
   throw new Error(
-    'Missing Supabase configuration: VITE_SUPABASE_PUBLISHABLE_KEY is not defined.'
+    `Missing Supabase configuration: ${missingEnvVars.join(', ')} ${missingEnvVars.length > 1 ? 'are' : 'is'} not defined.`
   );
 }
 


### PR DESCRIPTION
## Summary
- load Supabase credentials from the shared environment configuration instead of hard-coded literals
- throw explicit errors when the required Supabase environment variables are missing before creating the client

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e3f43fb45083298e6173f6721cfc59